### PR TITLE
Use netgen4smesh 6.2.1804 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: pwsh
         run: |
           mkdir conda
-          conda build  ci/conda -c conda-forge --python=3.7 --output-folder conda
+          conda build  ci/conda -c conda-forge -c trelau --output-folder conda
 
       - name: "Upload conda package"
         uses: actions/upload-artifact@v2
@@ -78,7 +78,7 @@ jobs:
         run: |
           mkdir conda
           source activate
-          conda build  ci/conda -c conda-forge --python=3.7 --output-folder conda
+          conda build  ci/conda -c conda-forge -c trelau --output-folder conda
 
       - name: "Upload conda package"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: pwsh
         run: |
           mkdir conda
-          conda build  ci/conda -c conda-forge --output-folder conda
+          conda build  ci/conda -c conda-forge --python=3.7 --output-folder conda
 
       - name: "Upload conda package"
         uses: actions/upload-artifact@v2
@@ -78,7 +78,7 @@ jobs:
         run: |
           mkdir conda
           source activate
-          conda build  ci/conda -c conda-forge --output-folder conda
+          conda build  ci/conda -c conda-forge --python=3.7 --output-folder conda
 
       - name: "Upload conda package"
         uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ if (BUILD_TESTS)
     if (ENABLE_NETGEN)
         add_executable(test_Netgen test/Netgen.t.cpp)
         target_include_directories(test_Netgen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
-        target_link_libraries(test_Netgen Catch2::Catch2 ${SMESH_LIBRARIES} TKPRim)
+        target_link_libraries(test_Netgen Catch2::Catch2 ${SMESH_LIBRARIES} TKPrim)
         catch_discover_tests(test_Netgen)
     endif()
 

--- a/ci/conda/bld.bat
+++ b/ci/conda/bld.bat
@@ -10,7 +10,7 @@ cmake -G "Ninja" ^
     -D PTHREAD_LIB_DIRS:FILEPATH="%LIBRARY_PREFIX%/lib" ^
     -D Boost_NO_BOOST_CMAKE:BOOL=ON ^
     -D ENABLE_LIB_NAMING:BOOL=OFF ^
-    -D BUILD_TESTS:BOOL=ON ^
+    -D BUILD_TESTS:BOOL=OFF ^
     ..
 
 if errorlevel 1 exit 1

--- a/ci/conda/bld.bat
+++ b/ci/conda/bld.bat
@@ -10,7 +10,7 @@ cmake -G "Ninja" ^
     -D PTHREAD_LIB_DIRS:FILEPATH="%LIBRARY_PREFIX%/lib" ^
     -D Boost_NO_BOOST_CMAKE:BOOL=ON ^
     -D ENABLE_LIB_NAMING:BOOL=OFF ^
-    -D BUILD_TESTS:BOOL=OFF ^
+    -D BUILD_TESTS:BOOL=ON ^
     ..
 
 if errorlevel 1 exit 1

--- a/ci/conda/bld.bat
+++ b/ci/conda/bld.bat
@@ -10,6 +10,7 @@ cmake -G "Ninja" ^
     -D PTHREAD_LIB_DIRS:FILEPATH="%LIBRARY_PREFIX%/lib" ^
     -D Boost_NO_BOOST_CMAKE:BOOL=ON ^
     -D ENABLE_LIB_NAMING:BOOL=OFF ^
+    -D BUILD_TESTS:BOOL=ON ^
     ..
 
 if errorlevel 1 exit 1

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -1,23 +1,14 @@
 mkdir -p build
 cd build
 
-if [ `uname` = "Darwin" ]; then
-      cpp_std=14
-else
-      cpp_std=17
-      sed -i 's#/home/conda/feedstock_root/build_artifacts/vtk_.*_build_env/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib.*;##g' ${PREFIX}/lib/cmake/vtk-8.2/Modules/vtkhdf5.cmake
-      sed -i 's#/home/conda/feedstock_root/build_artifacts/vtk_.*_build_env/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib.*;##g' ${PREFIX}/lib/cmake/vtk-8.2/VTKTargets-release.cmake
-fi
-
 cmake -G "Ninja" \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
       -D CMAKE_INSTALL_PREFIX:FILEPATH=$PREFIX \
       -D CMAKE_PREFIX_PATH:FILEPATH=$PREFIX \
       -D Boost_NO_BOOST_CMAKE:BOOL=ON \
-      -D CMAKE_CXX_STANDARD=${cpp_std} \
       -D ENABLE_MED:BOOL=OFF \
       -D ENABLE_NETGEN:BOOL=ON \
-      -D BUILD_TESTS:BOOL=ON \
+      -D BUILD_TESTS:BOOL=OFF \
       ..
 
 ninja install

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -17,7 +17,7 @@ cmake -G "Ninja" \
       -D CMAKE_CXX_STANDARD=${cpp_std} \
       -D ENABLE_MED:BOOL=OFF \
       -D ENABLE_NETGEN:BOOL=ON \
-      -D BUILD_TESTS:BOOL=ON \
+      -D BUILD_TESTS:BOOL=OFF \
       ..
 
 ninja install

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -17,7 +17,7 @@ cmake -G "Ninja" \
       -D CMAKE_CXX_STANDARD=${cpp_std} \
       -D ENABLE_MED:BOOL=OFF \
       -D ENABLE_NETGEN:BOOL=ON \
-      -D BUILD_TESTS:BOOL=OFF \
+      -D BUILD_TESTS:BOOL=ON \
       ..
 
 ninja install

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -1,11 +1,20 @@
 mkdir -p build
 cd build
 
+if [ `uname` = "Darwin" ]; then
+    cpp_std=14
+else
+    cpp_std=17
+    sed -i 's#/home/conda/feedstock_root/build_artifacts/vtk_.*_build_env/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib.*;##g' ${PREFIX}/lib/cmake/vtk-8.2/Modules/vtkhdf5.cmake
+    sed -i 's#/home/conda/feedstock_root/build_artifacts/vtk_.*_build_env/x86_64-conda_cos6-linux-gnu/sysroot/usr/lib.*;##g' ${PREFIX}/lib/cmake/vtk-8.2/VTKTargets-release.cmake
+fi
+
 cmake -G "Ninja" \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
       -D CMAKE_INSTALL_PREFIX:FILEPATH=$PREFIX \
       -D CMAKE_PREFIX_PATH:FILEPATH=$PREFIX \
       -D Boost_NO_BOOST_CMAKE:BOOL=ON \
+      -D CMAKE_CXX_STANDARD=${cpp_std} \
       -D ENABLE_MED:BOOL=OFF \
       -D ENABLE_NETGEN:BOOL=ON \
       -D BUILD_TESTS:BOOL=OFF \

--- a/ci/conda/build.sh
+++ b/ci/conda/build.sh
@@ -17,6 +17,7 @@ cmake -G "Ninja" \
       -D CMAKE_CXX_STANDARD=${cpp_std} \
       -D ENABLE_MED:BOOL=OFF \
       -D ENABLE_NETGEN:BOOL=ON \
+      -D BUILD_TESTS:BOOL=ON \
       ..
 
 ninja install

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - occt ==7.4.0
     - boost-cpp
     - pthreads-win32  # [win]
-    - netgen ==6.2.1808
+    - netgen4smesh ==6.2.1804
     - tbb-devel
     - catch2
 
@@ -31,7 +31,7 @@ requirements:
     - vtk
     - boost-cpp
     - pthreads-win32 # [win]
-    - netgen ==6.2.1808
+    - netgen4smesh ==6.2.1804
 
 about:
   home: https://github.com/LaughlinResearch/SMESH

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: ../..
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,7 +22,7 @@ requirements:
     - occt ==7.4.0
     - boost-cpp
     - pthreads-win32  # [win]
-    - netgen ==6.2.1808
+    - netgen ==6.2.1804
     - tbb-devel
     - catch2
 
@@ -31,7 +31,7 @@ requirements:
     - vtk
     - boost-cpp
     - pthreads-win32 # [win]
-    - netgen ==6.2.1808
+    - netgen ==6.2.1804
 
 about:
   home: https://github.com/LaughlinResearch/SMESH

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - occt ==7.4.0
     - boost-cpp
     - pthreads-win32  # [win]
-    - netgen ==6.2.1804
+    - netgen ==6.2.1808
     - tbb-devel
     - catch2
 
@@ -31,7 +31,7 @@ requirements:
     - vtk
     - boost-cpp
     - pthreads-win32 # [win]
-    - netgen ==6.2.1804
+    - netgen ==6.2.1808
 
 about:
   home: https://github.com/LaughlinResearch/SMESH

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: ../..
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: smesh
+  name: smesh4pyocct
   version: "8.3.0.3"
 
 source:

--- a/ci/conda/meta.yaml
+++ b/ci/conda/meta.yaml
@@ -24,11 +24,12 @@ requirements:
     - pthreads-win32  # [win]
     - netgen4smesh ==6.2.1804
     - tbb-devel
+    - vtk ==8.2.0
     - catch2
 
   run:
     - occt ==7.4.0
-    - vtk
+    - vtk ==8.2.0
     - boost-cpp
     - pthreads-win32 # [win]
     - netgen4smesh ==6.2.1804

--- a/src/StdMeshers/StdMeshers_Projection_2D.cxx
+++ b/src/StdMeshers/StdMeshers_Projection_2D.cxx
@@ -68,7 +68,11 @@
 #include <gp_Ax3.hxx>
 #include <gp_GTrsf.hxx>
 #include <TColStd_ListOfInteger.hxx>
-#include <IMeshData_Types.hxx>
+#include <Standard_Version.hxx>
+
+#if OCC_VERSION_MAJOR >= 7 && OCC_VERSION_MINOR >= 4
+    #include <IMeshData_Types.hxx>
+#endif
 
 
 using namespace std;
@@ -1331,7 +1335,12 @@ namespace {
       nbP += srcWires[iW]->NbPoints() - 1; // 1st and last points coincide
 
     // fill boundary points
-    IMeshData::Array1OfVertexOfDelaun srcVert( 1, 1 + nbP ), tgtVert( 1, 1 + nbP );
+#if OCC_VERSION_MAJOR == 7 && OCC_VERSION_MINOR >= 4
+	IMeshData::Array1OfVertexOfDelaun srcVert(1, 1 + nbP), tgtVert(1, 1 + nbP);
+#else
+	BRepMesh::Array1OfVertexOfDelaun srcVert(1, 1 + nbP), tgtVert(1, 1 + nbP);
+#endif
+
     vector< const SMDS_MeshNode* > bndSrcNodes( nbP + 1 ); bndSrcNodes[0] = 0;
     BRepMesh_Vertex v( 0, 0, BRepMesh_Frontier );
     for ( size_t iW = 0; iW < srcWires.size(); ++iW )

--- a/test/Netgen.t.cpp
+++ b/test/Netgen.t.cpp
@@ -4,12 +4,16 @@
 
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <TopoDS_Solid.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopAbs_ShapeEnum.hxx>
 
 #include <SMESH_Gen.hxx>
 #include <SMESH_Mesh.hxx>
 #include <SMESH_Hypothesis.hxx>
 #include <NETGENPlugin_SimpleHypothesis_3D.hxx>
 #include <NETGENPlugin_NETGEN_2D3D.hxx>
+#include <StdMeshers_LocalLength.hxx>
+#include <StdMeshers_Regular_1D.hxx>
 
 TEST_CASE("Mesh a box with tetrahedral elements.", "[netgen][solid]") {
 
@@ -30,11 +34,49 @@ TEST_CASE("Mesh a box with tetrahedral elements.", "[netgen][solid]") {
     bool success = gen->Compute(*mesh, box);
     REQUIRE(success == true);
 
-    REQUIRE(mesh->NbTetras() == 4767);
-    REQUIRE(mesh->NbNodes() == 1189);
+    REQUIRE(mesh->NbTetras() == 4385);
+    REQUIRE(mesh->NbNodes() == 1128);
 
     delete hyp;
     delete algo;
     delete mesh;
     delete gen;
+}
+
+TEST_CASE("Mesh a box with tetrahedral elements and a local edge length.", "[netgen][local]") {
+
+	TopoDS_Solid box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Solid();
+
+	TopExp_Explorer exp = TopExp_Explorer(box, TopAbs_EDGE);
+	const TopoDS_Shape& edge = exp.Current();
+
+	SMESH_Gen* gen = new SMESH_Gen();
+	SMESH_Mesh* mesh = gen->CreateMesh(0, true);
+
+	NETGENPlugin_SimpleHypothesis_3D* hyp3d = new NETGENPlugin_SimpleHypothesis_3D(0, 0, gen);
+	hyp3d->SetLocalLength(1.0);
+	NETGENPlugin_NETGEN_2D3D* algo3d = new NETGENPlugin_NETGEN_2D3D(1, 0, gen);
+
+	StdMeshers_LocalLength* hyp1d = new StdMeshers_LocalLength(2, 0, gen);
+	hyp1d->SetLength(0.1);
+	StdMeshers_Regular_1D* algo1d = new StdMeshers_Regular_1D(3, 0, gen);
+
+	mesh->ShapeToMesh(box);
+	mesh->AddHypothesis(box, 0);
+	mesh->AddHypothesis(box, 1);
+	mesh->AddHypothesis(edge, 2);
+	mesh->AddHypothesis(edge, 3);
+
+	bool success = gen->Compute(*mesh, box);
+	REQUIRE(success == true);
+
+	REQUIRE(mesh->NbTetras() == 34709);
+	REQUIRE(mesh->NbNodes() == 6804);
+
+	delete hyp3d;
+	delete algo3d;
+	delete hyp1d;
+	delete algo1d;
+	delete mesh;
+	delete gen;
 }


### PR DESCRIPTION
Since there are performance regressions (due to a patch being removed) from conda-forge SMESH, set this repo up to use a special version of netgen so that ultimately can get pyocct back to its working state...